### PR TITLE
Adjust top camera bar size and add camera screen

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5209,6 +5209,15 @@
         "url-parse": "^1.4.4"
       }
     },
+    "expo-camera": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/expo-camera/-/expo-camera-7.0.0.tgz",
+      "integrity": "sha512-OukSvj9dzrTdADDfMZQlxfCyLjwg/nyTm2u9NDFQh6poEmu+IE2gn5ICnc7pmqR+ctAmU312KiRcLoBe/6sfIw==",
+      "requires": {
+        "lodash": "^4.6.0",
+        "prop-types": "^15.6.0"
+      }
+    },
     "expo-constants": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/expo-constants/-/expo-constants-7.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "color": "^3.1.2",
     "expo": "^35.0.0",
     "expo-asset": "^7.0.0",
+    "expo-camera": "^7.0.0",
     "expo-constants": "^7.0.0",
     "expo-font": "^7.0.0",
     "expo-web-browser": "^7.0.0",

--- a/src/actions/UIControlAction.tsx
+++ b/src/actions/UIControlAction.tsx
@@ -1,0 +1,7 @@
+export const UI_SET_STATUS_BAR_HEIGHT: 'UI_SET_STATUS_BAR_HEIGHT' =
+  'UI_SET_STATUS_BAR_HEIGHT';
+
+export const setStatusBarHeight = (height: number) => ({
+  type: UI_SET_STATUS_BAR_HEIGHT,
+  payload: height,
+});

--- a/src/components/HikariStatusBar.tsx
+++ b/src/components/HikariStatusBar.tsx
@@ -1,0 +1,63 @@
+import React, { useState, useEffect } from 'react';
+import { connect } from 'react-redux';
+
+/* Components */
+import { StatusBar } from 'react-native';
+
+/* Actions */
+import { setStatusBarHeight } from '../actions/UIControlAction';
+
+/* Selectors */
+import { getStatusBarHeight } from '../reducers/UIControlReducer';
+
+/* Constants */
+import Constants from 'expo-constants';
+
+/* Types */
+declare interface IHikariStatusBar {
+  reportStatusBarHeight: (height: number) => void;
+  statusBarHeight: number;
+}
+
+const mapStateToProps = (state: any) => ({
+  statusBarHeight: getStatusBarHeight(state),
+});
+
+const mapDispatchToProps = (dispatch: any) => ({
+  reportStatusBarHeight: (height: number) =>
+    dispatch(setStatusBarHeight(height)),
+});
+
+const HikariStatusBar = ({
+  reportStatusBarHeight,
+  statusBarHeight,
+}: IHikariStatusBar) => {
+  // States
+  const [hideStatusBar, setHideStatusBar] = useState(false);
+
+  // Effects
+  useEffect(() => {
+    // A hacky way to get the correct status bar height.
+    // The native can only compute the correct status bar height when
+    // it is shown. Hence the status bar is first visible then hidden.
+    const { statusBarHeight } = Constants;
+    if (!hideStatusBar && statusBarHeight > 0) {
+      reportStatusBarHeight(statusBarHeight);
+    }
+  }, [hideStatusBar]);
+
+  useEffect(() => {
+    if (statusBarHeight > 0) {
+      setHideStatusBar(true);
+    } else {
+      setHideStatusBar(false);
+    }
+  }, [statusBarHeight]);
+
+  return <StatusBar hidden={hideStatusBar} />;
+};
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(HikariStatusBar);

--- a/src/reducers/CameraReducer.tsx
+++ b/src/reducers/CameraReducer.tsx
@@ -1,10 +1,5 @@
-// @flow
-
 /* Actions */
 import { CAMERA_CHANGING_CAPTURING_STATE } from '../actions/CameraAction';
-
-/* Selectors */
-import { getCameraState } from './DataSelector';
 
 const DEFAULT_STATE = {
   capturingPhoto: false,
@@ -24,5 +19,7 @@ export default (state = DEFAULT_STATE, action) => {
 };
 
 /* Selector */
+export const getCameraState = (state) => state.camera;
+
 export const getIsCapturingPhoto = (state) =>
   getCameraState(state).capturingPhoto;

--- a/src/reducers/DataReducer.tsx
+++ b/src/reducers/DataReducer.tsx
@@ -3,9 +3,11 @@ import { combineReducers } from 'redux';
 
 /* Reducers */
 import CameraReducer from './CameraReducer';
+import UIControlReducer from './UIControlReducer';
 
 const reducers = {
   camera: CameraReducer,
+  ui: UIControlReducer,
 };
 
 export default combineReducers(reducers);

--- a/src/reducers/DataSelector.tsx
+++ b/src/reducers/DataSelector.tsx
@@ -1,6 +1,0 @@
-// @flow
-
-/* Selector */
-export const getDataState = (state) => state.data;
-
-export const getCameraState = (state) => getDataState(state).camera;

--- a/src/reducers/UIControlReducer.tsx
+++ b/src/reducers/UIControlReducer.tsx
@@ -1,0 +1,25 @@
+/* Actions */
+import { UI_SET_STATUS_BAR_HEIGHT } from '../actions/UIControlAction';
+
+const DEFAULT_STATE = {
+  statusBarHeight: 0,
+};
+
+export default (state = DEFAULT_STATE, action: any) => {
+  switch (action.type) {
+    case UI_SET_STATUS_BAR_HEIGHT:
+      return {
+        ...state,
+        statusBarHeight: action.payload,
+      };
+    default:
+      break;
+  }
+  return state;
+};
+
+/* Selector */
+export const getUIControlState = (state: any) => state.ui;
+
+export const getStatusBarHeight = (state: any) =>
+  getUIControlState(state).statusBarHeight;

--- a/src/screens/camera/CameraBottomBar.tsx
+++ b/src/screens/camera/CameraBottomBar.tsx
@@ -20,7 +20,7 @@ import BottomBackgroundImage from '../../assets/images/background_bottom.png';
 const styles = StyleSheet.create({
   wrapper: {
     width: '100%',
-    height: 108,
+    height: 168,
     display: 'flex',
     flexDirection: 'row',
     justifyContent: 'space-around',

--- a/src/screens/camera/CameraContainer.tsx
+++ b/src/screens/camera/CameraContainer.tsx
@@ -1,0 +1,77 @@
+/* Components */
+import React, { useState, useEffect } from 'react';
+import { StyleSheet, View, Text } from 'react-native';
+import { Camera } from 'expo-camera';
+
+/* Utils */
+import * as Permissions from 'expo-permissions';
+
+/* Constants */
+const CAMERA_PERMISSION = {
+  CHECKING: 0,
+  DISALLOWED: 1,
+  GRANTED: 2,
+};
+
+/* Styles */
+const styles = StyleSheet.create({
+  wrapper: {
+    flex: 1,
+  },
+  cameraWrapper: {
+    flex: 1,
+  },
+  cameraViewWrapper: {
+    flex: 1,
+    backgroundColor: 'transparent',
+    flexDirection: 'row',
+    width: 200,
+    height: 200,
+  },
+});
+
+const CameraContainer = () => {
+  // States
+  const [cameraPermissionGranted, setCameraPermissionGranted] = useState(
+    CAMERA_PERMISSION.CHECKING,
+  );
+
+  // Effects
+  const checkCameraPermission = async () => {
+    const { status } = await Permissions.askAsync(Permissions.CAMERA);
+    if (status === 'granted') {
+      setCameraPermissionGranted(CAMERA_PERMISSION.GRANTED);
+    } else {
+      setCameraPermissionGranted(CAMERA_PERMISSION.DISALLOWED);
+    }
+  };
+
+  useEffect(() => {
+    checkCameraPermission();
+  }, []);
+
+  // Render
+  if (cameraPermissionGranted === CAMERA_PERMISSION.CHECKING) {
+    return <View />;
+  } else if (cameraPermissionGranted === CAMERA_PERMISSION.DISALLOWED) {
+    return (
+      <View style={styles.wrapper}>
+        <Text>Permissions Denied</Text>
+      </View>
+    );
+  }
+  return (
+    <View style={styles.wrapper}>
+      <Camera
+        style={styles.cameraWrapper}
+        type={Camera.Constants.Type.back}
+        flashMode={Camera.Constants.FlashMode.auto}
+        autoFocus={Camera.Constants.AutoFocus.on}
+      >
+        <View style={styles.cameraViewWrapper} />
+      </Camera>
+    </View>
+  );
+};
+
+export default CameraContainer;

--- a/src/screens/camera/CameraScreen.tsx
+++ b/src/screens/camera/CameraScreen.tsx
@@ -1,24 +1,32 @@
 import React from 'react';
 
 /* Components */
-import { StyleSheet, SafeAreaView, StatusBar } from 'react-native';
+import { StyleSheet, View } from 'react-native';
 import CameraTopBar from './CameraTopBar';
 import CameraBottomBar from './CameraBottomBar';
+import CameraContainer from './CameraContainer';
+import HikariStatusBar from '../../components/HikariStatusBar';
 
 /* Styles */
 const styles = StyleSheet.create({
   wrapper: {
-    display: 'flex',
+    flex: 1,
     flexDirection: 'column',
+  },
+  upperWrapper: {
+    flex: 1,
   },
 });
 
 const CameraScreen = () => (
-  <SafeAreaView style={styles.wrapper}>
-    <StatusBar hidden />
-    <CameraTopBar />
+  <View style={styles.wrapper}>
+    <HikariStatusBar />
+    <View style={styles.upperWrapper}>
+      <CameraContainer />
+      <CameraTopBar />
+    </View>
     <CameraBottomBar />
-  </SafeAreaView>
+  </View>
 );
 
 export default CameraScreen;

--- a/src/screens/camera/CameraTopBar.tsx
+++ b/src/screens/camera/CameraTopBar.tsx
@@ -1,61 +1,89 @@
 import React from 'react';
+import { connect } from 'react-redux';
 
 /* Components */
-import { StyleSheet, ImageBackground } from 'react-native';
-import {
-  withTheme,
-  IconButton,
-  Colors as PaperColors,
-} from 'react-native-paper';
+import { StyleSheet, ImageBackground, View } from 'react-native';
+import { IconButton, Colors as PaperColors } from 'react-native-paper';
 import CartIcon from '../../assets/icons/cart.png';
 import FlashIcon from '../../assets/icons/flash.png';
 import LoopIcon from '../../assets/icons/loop.png';
 import SettingsIcon from '../../assets/icons/settings.png';
 import TopBackgroundImage from '../../assets/images/background_top.png';
 
+/* Selectors */
+import { getStatusBarHeight } from '../../reducers/UIControlReducer';
+
+/* Constants */
+const CAMERA_TOP_BAR_HEIGHT = 30;
+
 /* Types */
+declare interface ICameraTopBar {
+  statusBarHeight: number;
+}
+
+declare interface IStyles {
+  statusBarHeight: number;
+}
 
 /* Styles */
-const styles = StyleSheet.create({
-  wrapper: {
-    width: '100%',
-    height: 50,
-    display: 'flex',
-    flexDirection: 'row',
-    justifyContent: 'space-around',
-    alignItems: 'center',
-  },
+const styles = ({ statusBarHeight }: IStyles) =>
+  StyleSheet.create({
+    wrapper: {
+      width: '100%',
+      height: CAMERA_TOP_BAR_HEIGHT + statusBarHeight,
+      position: 'absolute',
+      top: 0,
+      left: 0,
+    },
+    mainWrapper: {
+      position: 'absolute',
+      width: '100%',
+      height: CAMERA_TOP_BAR_HEIGHT,
+      top: statusBarHeight - 10,
+      display: 'flex',
+      flexDirection: 'row',
+      justifyContent: 'space-around',
+      alignItems: 'center',
+    },
+  });
+
+const mapStateToProps = (state: any) => ({
+  statusBarHeight: getStatusBarHeight(state),
 });
 
-const CameraTopBar = () => {
+const CameraTopBar = ({ statusBarHeight }: ICameraTopBar) => {
+  const pStyles = styles({ statusBarHeight });
+
   return (
-    <ImageBackground source={TopBackgroundImage} style={styles.wrapper}>
-      <IconButton
-        icon={CartIcon}
-        size={24}
-        color={PaperColors.white}
-        animated
-      />
-      <IconButton
-        icon={FlashIcon}
-        size={24}
-        color={PaperColors.white}
-        animated
-      />
-      <IconButton
-        icon={LoopIcon}
-        size={24}
-        color={PaperColors.white}
-        animated
-      />
-      <IconButton
-        icon={SettingsIcon}
-        size={24}
-        color={PaperColors.white}
-        animated
-      />
+    <ImageBackground source={TopBackgroundImage} style={pStyles.wrapper}>
+      <View style={pStyles.mainWrapper}>
+        <IconButton
+          icon={CartIcon}
+          size={24}
+          color={PaperColors.white}
+          animated
+        />
+        <IconButton
+          icon={FlashIcon}
+          size={24}
+          color={PaperColors.white}
+          animated
+        />
+        <IconButton
+          icon={LoopIcon}
+          size={24}
+          color={PaperColors.white}
+          animated
+        />
+        <IconButton
+          icon={SettingsIcon}
+          size={24}
+          color={PaperColors.white}
+          animated
+        />
+      </View>
     </ImageBackground>
   );
 };
 
-export default withTheme(CameraTopBar);
+export default connect(mapStateToProps)(CameraTopBar);


### PR DESCRIPTION
An alternative to `SafeAreaView` is proposed as status bar does not fit on IPhone 7 but
somewhat fit on IPhone X. So it is decided that status bar should be invisible.

However, `expo` could result in a peculiar bug where the constant
of the status bar height would become zero when the status bar is turned off
and the App is reloaded. Some hacky work-around is proposed to fight against
this weird bug.

It is estimated that such queer bug should not live in the production enviroment.
But for sake of development, a hacky component called `HikariStatusBar` gives its
birth.